### PR TITLE
feat: track proof stats to make performance tweaks easier

### DIFF
--- a/tensor_theorem_prover/prover/Proof.py
+++ b/tensor_theorem_prover/prover/Proof.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from textwrap import indent
 
 from tensor_theorem_prover.normalize.to_cnf import CNFDisjunction
+from tensor_theorem_prover.prover.ProofStats import ProofStats
 from tensor_theorem_prover.types import Constant, Variable, Term
 from tensor_theorem_prover.types.Function import BoundFunction
 from tensor_theorem_prover.util.find_variables_in_terms import find_variables_in_terms
@@ -16,6 +17,7 @@ class Proof:
     goal: CNFDisjunction
     similarity: float
     leaf_proof_step: ProofStep
+    stats: ProofStats
 
     @property
     def depth(self) -> int:

--- a/tensor_theorem_prover/prover/ProofStats.py
+++ b/tensor_theorem_prover/prover/ProofStats.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from dataclasses import dataclass
+
+
+@dataclass
+class ProofStats:
+    """Stats on how complex a proof was to complete"""
+
+    attempted_unifications: int = 0
+    successful_unifications: int = 0
+    similarity_comparisons: int = 0
+    similarity_cache_hits: int = 0
+    attempted_resolutions: int = 0
+    successful_resolutions: int = 0
+    max_resolvent_width_seen: int = 0
+    max_depth_seen: int = 0
+    discarded_proofs: int = 0

--- a/tensor_theorem_prover/prover/ProofStepAccumulator.py
+++ b/tensor_theorem_prover/prover/ProofStepAccumulator.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
+from copy import copy
 from typing import Optional
+
+from tensor_theorem_prover.prover.ProofStats import ProofStats
 
 from .ProofStep import ProofStep
 
@@ -8,7 +11,7 @@ class ProofStepAccumulator:
     """Helper class which accumulates successful proof steps and keeps track of the minimum proof similarity"""
 
     max_proofs: Optional[int]
-    scored_proof_steps: list[tuple[float, ProofStep]]
+    scored_proof_steps: list[tuple[float, ProofStep, ProofStats]]
     min_similarity: float
 
     def __init__(self, max_proofs: Optional[int] = None) -> None:
@@ -23,7 +26,7 @@ class ProofStepAccumulator:
             and len(self.scored_proof_steps) >= self.max_proofs
         )
 
-    def add_proof(self, proof_step: ProofStep) -> None:
+    def add_proof(self, proof_step: ProofStep, stats: ProofStats) -> None:
         """Add a proof step to the accumulator"""
 
         # TODO: Make combining similarities customizable rather than always taking the minimum
@@ -33,10 +36,12 @@ class ProofStepAccumulator:
             similarity = min(similarity, cur_step.parent.similarity)
             cur_step = cur_step.parent
 
-        self.scored_proof_steps.append((similarity, proof_step))
+        # make sure to clone the stats before appending, since the stats will continue to get mutated after this
+        self.scored_proof_steps.append((similarity, proof_step, copy(stats)))
         self.scored_proof_steps.sort(key=lambda x: x[0], reverse=True)
         if self.max_proofs and len(self.scored_proof_steps) > self.max_proofs:
             # Remove the proof step with the lowest similarity
             self.scored_proof_steps.pop()
+            stats.discarded_proofs += 1
         # Update the minimum similarity
         self.min_similarity = self.scored_proof_steps[-1][0]

--- a/tensor_theorem_prover/prover/__init__.py
+++ b/tensor_theorem_prover/prover/__init__.py
@@ -1,9 +1,6 @@
 from .Proof import Proof
 from .ProofStep import ProofStep
+from .ProofStats import ProofStats
 from .ResolutionProver import ResolutionProver
 
-__all__ = (
-    "ResolutionProver",
-    "Proof",
-    "ProofStep",
-)
+__all__ = ("ResolutionProver", "Proof", "ProofStep", "ProofStats")

--- a/tensor_theorem_prover/prover/operations/resolve.py
+++ b/tensor_theorem_prover/prover/operations/resolve.py
@@ -3,6 +3,7 @@ import re
 from typing import Optional
 
 from tensor_theorem_prover.normalize.to_cnf import CNFDisjunction, CNFLiteral
+from tensor_theorem_prover.prover.ProofStats import ProofStats
 from tensor_theorem_prover.prover.ProofStep import ProofStep, SubstitutionsMap
 from tensor_theorem_prover.similarity import SimilarityFunc
 from tensor_theorem_prover.types import Atom, Term, Variable
@@ -16,6 +17,7 @@ def resolve(
     min_similarity_threshold: float = 0.5,
     similarity_func: Optional[SimilarityFunc] = None,
     parent: Optional[ProofStep] = None,
+    proof_stats: Optional[ProofStats] = None,
 ) -> list[ProofStep]:
     """Resolve a source and target CNF disjunction
 
@@ -33,13 +35,19 @@ def resolve(
         # we can only resolve literals with the opposite polarity
         if source_literal.polarity == target_literal.polarity:
             continue
+        if proof_stats:
+            proof_stats.attempted_unifications += 1
         unification = unify(
             source_literal.atom,
             target_literal.atom,
             min_similarity_threshold,
             similarity_func,
+            proof_stats,
         )
         if unification:
+            if proof_stats:
+                proof_stats.successful_unifications += 1
+
             resolvent = _build_resolvent(
                 source, target, source_literal, target_literal, unification
             )

--- a/tensor_theorem_prover/similarity.py
+++ b/tensor_theorem_prover/similarity.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Callable, Dict, Iterable, Tuple, Union
 import numpy as np
 from numpy.linalg import norm
+from tensor_theorem_prover.prover.ProofStats import ProofStats
 
 from tensor_theorem_prover.types.Constant import Constant
 from tensor_theorem_prover.types.Predicate import Predicate
@@ -17,6 +18,7 @@ SimilarityCache = Dict[Tuple[Union[str, int], Union[str, int]], float]
 def similarity_with_cache(
     similarity: SimilarityFunc,
     cache: SimilarityCache,
+    proof_stats: ProofStats,
 ) -> SimilarityFunc:
     """cache all similarity scores by the object id of the items being compared"""
 
@@ -26,7 +28,9 @@ def similarity_with_cache(
         key1: str | int = item1.symbol if item1.embedding is None else id(item1)
         key2: str | int = item2.symbol if item2.embedding is None else id(item2)
         key = (key1, key2)
-        if key not in cache:
+        if key in cache:
+            proof_stats.similarity_cache_hits += 1
+        else:
             cache[key] = similarity(item1, item2)
         return cache[key]
 

--- a/tests/prover/test_ResolutionProver.py
+++ b/tests/prover/test_ResolutionProver.py
@@ -255,7 +255,7 @@ def test_prove_all_with_multiple_valid_proof_paths_and_embedding_similarities() 
 
     goal = grandpa_of(X, bart)
 
-    proofs = prover.prove_all(goal)
+    proofs, stats = prover.prove_all_with_stats(goal)
     # should have a separate proof for each combo of dad/father in grandpa_of
     assert len(proofs) == 4
     # proofs should be sorted by similarity
@@ -263,6 +263,23 @@ def test_prove_all_with_multiple_valid_proof_paths_and_embedding_similarities() 
     assert proofs[-1].similarity < 0.99
     for proof in proofs:
         assert proof.substitutions == {X: abe}
+
+    # make sure that stats look sane
+    assert proofs[0].stats.successful_unifications < stats.successful_unifications
+    assert proofs[0].stats.attempted_unifications < stats.attempted_unifications
+    assert proofs[0].stats.attempted_resolutions < stats.attempted_resolutions
+    assert proofs[0].stats.successful_resolutions < stats.successful_resolutions
+    assert proofs[0].stats.similarity_comparisons < stats.similarity_comparisons
+    assert proofs[0].stats.similarity_cache_hits < stats.similarity_cache_hits
+
+    assert stats.attempted_resolutions > 0
+    assert stats.attempted_unifications > 0
+    assert stats.successful_resolutions > 0
+    assert stats.successful_unifications > 0
+    assert stats.similarity_comparisons > 0
+    assert stats.similarity_cache_hits > 0
+    assert stats.max_resolvent_width_seen > 0
+    assert stats.max_depth_seen > 0
 
 
 def test_prove_all_can_limit_the_number_of_returned_proofs() -> None:

--- a/tests/test_similarity.py
+++ b/tests/test_similarity.py
@@ -1,5 +1,6 @@
 import pytest
 import numpy as np
+from tensor_theorem_prover.prover.ProofStats import ProofStats
 
 from tensor_theorem_prover.similarity import (
     SimilarityCache,
@@ -56,11 +57,14 @@ def test_max_similarity_takes_the_max_of_all_passed_similarity_measures() -> Non
 
 
 def test_similarity_with_cache() -> None:
+    stats = ProofStats()
     item1 = Constant("a", np.array([1, 0, 1]))
     item2 = Constant("b", np.array([0, 1, 1]))
     cache: SimilarityCache = {(id(item1), id(item2)): 0.75}
-    similarity = similarity_with_cache(cosine_similarity, cache)
+    similarity = similarity_with_cache(cosine_similarity, cache, stats)
     assert similarity(item1, item2) == pytest.approx(0.75)
+    assert stats.similarity_cache_hits == 1
     cache.clear()
     assert similarity(item1, item2) == pytest.approx(0.5)
     assert cache[(id(item1), id(item2))] == pytest.approx(0.5)
+    assert stats.similarity_cache_hits == 1


### PR DESCRIPTION
This PR adds a `stats` key to returned proofs which keeps track of the stats around operations performed in the prover to generate the proof. It also adds a `prove_all_with_stats` method which will return a list of proofs along with the final stats for the entire operation if needed.