### PR TITLE
fix: improving consistency on identical runs

### DIFF
--- a/src/prover/resolution_prover.rs
+++ b/src/prover/resolution_prover.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use pyo3::prelude::*;
 
@@ -19,7 +19,7 @@ pub struct ResolutionProverBackend {
     similarity_cache: Option<SimilarityCache>,
     skip_seen_resolvents: bool,
     find_highest_similarity_proofs: bool,
-    base_knowledge: HashSet<PyArcItem<CNFDisjunction>>,
+    base_knowledge: BTreeSet<PyArcItem<CNFDisjunction>>,
 }
 #[pymethods]
 impl ResolutionProverBackend {
@@ -33,7 +33,7 @@ impl ResolutionProverBackend {
         cache_similarity: bool,
         skip_seen_resolvents: bool,
         find_highest_similarity_proofs: bool,
-        base_knowledge: HashSet<PyArcItem<CNFDisjunction>>,
+        base_knowledge: BTreeSet<PyArcItem<CNFDisjunction>>,
     ) -> Self {
         Self {
             max_proof_depth,
@@ -52,7 +52,7 @@ impl ResolutionProverBackend {
         }
     }
 
-    pub fn extend_knowledge(&mut self, knowledge: HashSet<CNFDisjunction>) {
+    pub fn extend_knowledge(&mut self, knowledge: BTreeSet<CNFDisjunction>) {
         self.base_knowledge.extend(knowledge_to_arc(knowledge));
     }
 
@@ -60,8 +60,8 @@ impl ResolutionProverBackend {
     /// Return the proofs and the stats for the proof search.
     pub fn prove_all_with_stats(
         &self,
-        inverted_goals: HashSet<CNFDisjunction>,
-        extra_knowledge: Option<HashSet<CNFDisjunction>>,
+        inverted_goals: BTreeSet<CNFDisjunction>,
+        extra_knowledge: Option<BTreeSet<CNFDisjunction>>,
         max_proofs: Option<usize>,
         skip_seen_resolvents: Option<bool>,
     ) -> (Vec<Proof>, ProofStats) {
@@ -106,7 +106,7 @@ impl ResolutionProverBackend {
     }
 
     pub fn reset(&mut self) {
-        self.base_knowledge = HashSet::new();
+        self.base_knowledge = BTreeSet::new();
         self.purge_similarity_cache();
     }
 }
@@ -115,7 +115,7 @@ impl ResolutionProverBackend {
     fn prove_all_recursive(
         &self,
         goal: PyArcItem<CNFDisjunction>,
-        knowledge: &HashSet<PyArcItem<CNFDisjunction>>,
+        knowledge: &BTreeSet<PyArcItem<CNFDisjunction>>,
         ctx: &mut ProofContext,
         depth: usize,
         parent_state: Option<ProofStepNode>,
@@ -177,7 +177,7 @@ impl ResolutionProverBackend {
     }
 }
 
-fn knowledge_to_arc(knowledge: HashSet<CNFDisjunction>) -> HashSet<PyArcItem<CNFDisjunction>> {
+fn knowledge_to_arc(knowledge: BTreeSet<CNFDisjunction>) -> BTreeSet<PyArcItem<CNFDisjunction>> {
     knowledge
         .into_iter()
         .map(|x| PyArcItem::new(x.clone()))

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -122,12 +122,12 @@ def test_performance_with_mixed_amr_reasoner_batch() -> None:
     start = time.time()
     total_proofs = 0
     all_knowledge = []
-    for sample in batch[0:8]:
+    for sample in batch[0:10]:
         all_knowledge.extend(sample["knowledge"])
     prover = ResolutionProver(
         knowledge=all_knowledge,
         similarity_func=max_similarity([cosine_similarity, partial_symbol_compare]),
-        max_proof_depth=10,
+        max_proof_depth=12,
         max_resolvent_width=6,
         min_similarity_threshold=0.5,
         skip_seen_resolvents=True,


### PR DESCRIPTION
Previously, running the same inputs would take wildly varying amounts of time. This is because knowledge was stored in a HashMap, so iterating over the knowledge would not have a consistent order, especially between runs. Checking knowledge in different orders can result in a very large difference in how long it takes to find proofs, which makes it especially difficult to benchmark between runs, and is generally not a great look. This PR changes knowledge to be stored in `BTreeSet` instead of a `HashMap` so the ordering of knowledge in consistent.